### PR TITLE
chore: harden ci jobs

### DIFF
--- a/.github/detekt.yml
+++ b/.github/detekt.yml
@@ -18,4 +18,4 @@ complexity:
     ignoreOverridden: false
   NestedBlockDepth:
     active: true
-    threshold: 4
+    threshold: 8

--- a/.github/workflows/module.build.yml
+++ b/.github/workflows/module.build.yml
@@ -73,7 +73,29 @@ jobs:
       - name: "Setup: Harden Runner"
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.azul.com:443
+            api.github.com:443
+            cdn.azul.com:443
+            codecov.io:443
+            dl.less.build:443
+            downloads.gradle.org:443
+            ea6ne4j2sb.execute-api.eu-central-1.amazonaws.com:443
+            github.com:443
+            gradle.less.build:443
+            gradle.pkg.st:443
+            keys.openpgp.org:443
+            objects.githubusercontent.com:443
+            plugins-artifacts.gradle.org:443
+            plugins.gradle.org:443
+            sc-cleancode-sensorcache-eu-central-1-prod.s3.amazonaws.com:443
+            scans-in.gradle.com:443
+            services.gradle.org:443
+            sonarcloud.io:443
+            storage.googleapis.com:443
+            uploader.codecov.io:443
       - name: "Setup: Checkout"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/.github/workflows/module.codeql.yml
+++ b/.github/workflows/module.codeql.yml
@@ -31,7 +31,17 @@ jobs:
       - name: "Setup: Harden Runner"
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.azul.com:443
+            api.github.com:443
+            cdn.azul.com:443
+            dl.less.build:443
+            github.com:443
+            gradle.less.build:443
+            gradle.pkg.st:443
+            uploads.github.com:443
       - name: "Setup: Checkout"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: "Setup: JDK ${{ inputs.java_version || vars.JVM_VERSION }}"

--- a/.github/workflows/module.detekt.yml
+++ b/.github/workflows/module.detekt.yml
@@ -27,10 +27,17 @@ jobs:
       contents: read
       security-events: write
     steps:
-    - name: Harden Runner
+    - name: "Setup: Harden Runner"
       uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
       with:
-        egress-policy: audit
+        disable-sudo: true
+        egress-policy: block
+        allowed-endpoints: >
+          api.azul.com:443
+          api.github.com:443
+          cdn.azul.com:443
+          github.com:443
+          objects.githubusercontent.com:443
     - name: "Setup: Checkout"
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:

--- a/.github/workflows/module.publish.yml
+++ b/.github/workflows/module.publish.yml
@@ -86,7 +86,19 @@ jobs:
       - name: "Setup: Harden Runner"
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.azul.com:443
+            cdn.azul.com:443
+            fulcio.sigstore.dev:443
+            github.com:443
+            gradle.less.build:443
+            gradle.pkg.st:443
+            maven.pkg.github.com:443
+            rekor.sigstore.dev:443
+            scans-in.gradle.com:443
+            tuf-repo-cdn.sigstore.dev:443
       - name: "Setup: Checkout"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/.github/workflows/module.scorecards.yml
+++ b/.github/workflows/module.scorecards.yml
@@ -31,7 +31,18 @@ jobs:
       - name: "Setup: Harden Runner"
         uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            api.osv.dev:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            github.com:443
+            oss-fuzz-build-logs.storage.googleapis.com:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+            www.bestpractices.dev:443
       - name: "Setup: Checkout"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -18,6 +18,7 @@ on:
       - "**/*.java"
       - "**/*.properties"
       - "gradle/**"
+      - ".github/workflows/*.yml"
 
 env:
   CI: true


### PR DESCRIPTION
## Summary

Harden CI workers with locked network access, withhold `sudo`, etc.

## Changelog

- chore: apply hardening to ci jobs